### PR TITLE
Fixes linking to `index.php` in client build

### DIFF
--- a/podman/rebuildClient.bash
+++ b/podman/rebuildClient.bash
@@ -6,6 +6,6 @@ then
     unlink index.php
 fi
 
-npm run build:dev && export HASH=$(ls dist) && ln -sf dist/${HASH}/index.html index.php
+npm run build:dev && export HASH=$(ls -t dist | cut -d " " -f 1) && ln -sf dist/${HASH}/index.html index.php
 cd -
 echo Web client built and linked


### PR DESCRIPTION
When multiple folders are present in `dist`, the build breaks and `index.php` is not linked. This always resolves to the most recent folder in `dist`.