### PR TITLE
LIMS-659: Add a dummy sendmail script to write emails to disk

### DIFF
--- a/podman/entrypoint.bash
+++ b/podman/entrypoint.bash
@@ -1,4 +1,24 @@
 #!/bin/bash
+
+echo '#!/usr/bin/php
+
+<?php
+        $logfile = "/app/SynchWeb/emails.txt";
+        //* Get the email content
+        $log_output = "****" . date("Y-m-d H:i:s") . "****\r\n";
+        $handle = fopen("php://stdin", "r");
+        while(!feof($handle))
+        {
+                $buffer = trim(fgets($handle));
+                $log_output .= $buffer . "\r\n";
+        }
+        //* Write the log
+        file_put_contents($logfile, $log_output);
+?>' > /usr/sbin/sendmail
+chmod a+x /usr/sbin/sendmail
+touch /app/SynchWeb/emails.txt
+chmod a+w /app/SynchWeb/emails.txt
+
 app_home=/app/SynchWeb
 
 echo --------------------------------------------------


### PR DESCRIPTION
Ticket: [LIMS-659](https://jira.diamond.ac.uk/browse/LIMS-659)

Sendmail is not installed on the dev environment, so put a fake script in the expected path which can read in from php and output to a file on disk.