### PR TITLE
[LIMS-1409] Add Rocky Linux 8 dev environment

### DIFF
--- a/podman/Dockerfile-8.dockerfile
+++ b/podman/Dockerfile-8.dockerfile
@@ -1,0 +1,28 @@
+FROM rockylinux:8.9
+
+WORKDIR /app
+ 
+# Install httpd, PHP, git and required dependencies
+RUN dnf module enable php:7.4 -y && \
+    yum install -y wget git tar xz httpd mod_ssl && \
+    yum install -y php php-mysqlnd php-mbstring php-xml php-gd php-fpm php-cli php-ldap
+ 
+# Install Composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php composer-setup.php --install-dir=/tmp --filename=composer
+ 
+# Copy config
+COPY httpd.conf /etc/httpd/conf/
+
+RUN chmod 744 /etc/httpd/conf/httpd.conf
+ 
+# Create self signed certificate for use in dev
+RUN mkdir /etc/pki/tls/private/synchweb && \
+    mkdir /etc/pki/tls/certs/synchweb && \
+    openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes \
+            -out /etc/pki/tls/certs/synchweb/cert.pem \
+            -keyout /etc/pki/tls/private/synchweb/key.pem \
+            -subj "/C=UK/ST=Oxfordshire/L=Test/O=Test/OU=Test/CN=local-oidc-test.diamond.ac.uk"
+
+EXPOSE 8082 9003
+ENTRYPOINT ["/app/SynchWeb/entrypoint.bash", "-7"]

--- a/podman/run_synchweb.bash
+++ b/podman/run_synchweb.bash
@@ -50,6 +50,9 @@ do
             -s)
             initialSetUp=1
             ;;
+            -8)
+            phpVersion="8"
+            ;;
             -74)
             phpVersion="74"
             ;;
@@ -113,6 +116,9 @@ if [ $buildImage -eq 1 ]
 then
 
     echo Building $imageName image
+    if [ "$phpVersion" = "8" ]; then
+        dockerFieldSuffic="-8.dockerfile"
+    fi
     if [ "$phpVersion" = "74" ]; then
         dockerFieldSuffic="-7.4.dockerfile"
     fi


### PR DESCRIPTION
[LIMS-1407](https://jira.diamond.ac.uk/browse/LIMS-1407)

**Summary:**

Create new Dockerfile using Rocky Linux 8, rather than CentOS 7, given it's EoL for a few years now.

**Changes:**

- Add new RL8 Dockerfile image
- Add new `-8` option to `run_synchweb.sh`

**To test:**

- Run `run_synchweb.sh` with `./run-synchweb.sh -8 -b`, ensure image is built, and SynchWeb functions as normal
